### PR TITLE
lean how to use children prop, let navbar ON

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,10 +1,17 @@
 import { createBrowserRouter, RouterProvider } from "react-router-dom";
 import HomePage from "./pages/Home";
 import Products from "./pages/Products";
+import RootLayout from "./pages/Root";
 
 const router = createBrowserRouter([
-  { path: "/", element: <HomePage /> },
-  { path: "/products", element: <Products /> },
+  {
+    path: "/",
+    element: <RootLayout />,
+    children: [
+      { path: "/", element: <HomePage /> },
+      { path: "/products", element: <Products /> },
+    ],
+  },
 ]);
 
 function App() {

--- a/src/components/MainNavigation.js
+++ b/src/components/MainNavigation.js
@@ -1,0 +1,22 @@
+import { Link } from "react-router-dom";
+
+import classes from "./MainNavigation.module.css";
+
+const MainNavigation = () => {
+  return (
+    <header className={classes.header}>
+      <nav>
+        <ul className={classes.list}>
+          <li>
+            <Link to="/">Home</Link>
+          </li>
+          <li>
+            <Link to="/products">Products</Link>
+          </li>
+        </ul>
+      </nav>
+    </header>
+  );
+};
+
+export default MainNavigation;

--- a/src/components/MainNavigation.module.css
+++ b/src/components/MainNavigation.module.css
@@ -1,0 +1,23 @@
+.header {
+  max-width: 60rem;
+  margin: auto;
+  padding: 2rem;
+  display: flex;
+  justify-content: center;
+}
+
+.list {
+  display: flex;
+  gap: 1rem;
+}
+
+.list a {
+  text-decoration: none;
+  color: var(--color-primary-400);
+}
+
+.list a:hover,
+.list a.active {
+  color: var(--color-primary-800);
+  text-decoration: underline;
+}

--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -1,5 +1,5 @@
-import { Link } from "react-router-dom";
 import { Fragment } from "react";
+import { Link } from "react-router-dom";
 
 const HomePage = () => {
   return (

--- a/src/pages/Root.js
+++ b/src/pages/Root.js
@@ -1,0 +1,18 @@
+import { Fragment } from "react";
+import { Outlet } from "react-router-dom";
+
+import MainNavigation from "../components/MainNavigation";
+import classes from "./Root.module.css";
+
+const RootLayout = () => {
+  return (
+    <Fragment>
+      <MainNavigation />
+      <main className={classes.content}>
+        <Outlet />
+      </main>
+    </Fragment>
+  );
+};
+
+export default RootLayout;

--- a/src/pages/Root.module.css
+++ b/src/pages/Root.module.css
@@ -1,0 +1,4 @@
+.content {
+  margin: 2rem auto;
+  text-align: center;
+}


### PR DESCRIPTION
- navbar를 만들고, navbar에서도 라우터 기능을 사용하기 위해(link 등) 중첩된 라우터 구조를 생성한다.
- RouterProvider의 props를 받는 Root Layout을 생성하고, 여기에 다른 url을 가진 컴포넌트들을 자식 컴포넌트로 넣어준다. 
- 또한 navbar를 Route Layout의 자식 컴포넌트로 사용하여 항상 로딩되며 사용 가능하도록 구현한다. 